### PR TITLE
feat: add Slice and Custom Type asset management hooks

### DIFF
--- a/src/createSliceMachineActions.ts
+++ b/src/createSliceMachineActions.ts
@@ -1,15 +1,16 @@
 import { HookSystem } from "./lib";
+import { SliceMachineHooks, SliceMachineProject } from "./types";
+
+import { CustomTypeLibraryReadHookReturnType } from "./hooks/customTypeLibrary-read";
 import {
-	CustomTypeLibraryReadHookReturnType,
 	CustomTypeReadHookData,
 	CustomTypeReadHookReturnType,
+} from "./hooks/customType-read";
+import {
 	SliceLibraryReadHookData,
 	SliceLibraryReadHookReturnType,
-	SliceMachineHooks,
-	SliceMachineProject,
-	SliceReadHookData,
-	SliceReadHookReturnType,
-} from "./types";
+} from "./hooks/sliceLibrary-read";
+import { SliceReadHookData, SliceReadHookReturnType } from "./hooks/slice-read";
 
 export type ReadAllSliceModelsActionArgs<
 	TWithMetadata extends boolean = false,

--- a/src/createSliceMachinePluginRunner.ts
+++ b/src/createSliceMachinePluginRunner.ts
@@ -28,10 +28,14 @@ import {
  */
 export const REQUIRED_ADAPTER_HOOKS: SliceMachineHookTypes[] = [
 	"slice:read",
+	"slice:asset:update",
 	"slice:asset:read",
+	"slice:asset:delete",
 	"slice-library:read",
 	"custom-type:read",
+	"custom-type:asset:update",
 	"custom-type:asset:read",
+	"custom-type:asset:delete",
 	"custom-type-library:read",
 	"slice-simulator:setup:read",
 ];

--- a/src/createSliceMachinePluginRunner.ts
+++ b/src/createSliceMachinePluginRunner.ts
@@ -28,8 +28,10 @@ import {
  */
 export const REQUIRED_ADAPTER_HOOKS: SliceMachineHookTypes[] = [
 	"slice:read",
+	"slice:asset:read",
 	"slice-library:read",
 	"custom-type:read",
+	"custom-type:asset:read",
 	"custom-type-library:read",
 	"slice-simulator:setup:read",
 ];

--- a/src/hooks/customType-asset-delete.ts
+++ b/src/hooks/customType-asset-delete.ts
@@ -1,0 +1,38 @@
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `custom-type:asset:delete` hook handlers.
+ */
+export type CustomTypeAssetDeleteHookData = {
+	customTypeID: string;
+	assetID: string;
+};
+
+/**
+ * Return value for `custom-type:asset:delete` hook handlers.
+ */
+export type CustomTypeAssetDeleteHookReturnType = void;
+
+/**
+ * Base version of `custom-type:asset:delete` without plugin runner context.
+ *
+ * @internal
+ */
+export type CustomTypeAssetDeleteHookBase = SliceMachineHook<
+	CustomTypeAssetDeleteHookData,
+	CustomTypeAssetDeleteHookReturnType
+>;
+
+/**
+ * Handler for the `custom-type:asset:delete` hook. The hook is called when a
+ * Custom Type asset is deleted.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type CustomTypeAssetDeleteHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<CustomTypeAssetDeleteHookBase, TPluginOptions>;

--- a/src/hooks/customType-asset-read.ts
+++ b/src/hooks/customType-asset-read.ts
@@ -1,0 +1,44 @@
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `custom-type:asset:read` hook handlers.
+ */
+export type CustomTypeAssetReadHookData = {
+	customTypeID: string;
+	assetID: string;
+};
+
+/**
+ * Return value for `custom-type:asset:read` hook handlers.
+ */
+export type CustomTypeAssetReadHookReturnType = {
+	data: Buffer;
+};
+
+/**
+ * Base version of `custom-type:asset:read` without plugin runner context.
+ *
+ * @internal
+ */
+export type CustomTypeAssetReadHookBase = SliceMachineHook<
+	CustomTypeAssetReadHookData,
+	CustomTypeAssetReadHookReturnType
+>;
+
+/**
+ * Handler for the `slice:asset:read` hook. The hook is called when a Custom
+ * Type's asset needs to be read.
+ *
+ * This hook is **required** to be implemented by adapters.
+ *
+ * This hook will only be called in adapters.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type CustomTypeAssetReadHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<CustomTypeAssetReadHookBase, TPluginOptions>;

--- a/src/hooks/customType-asset-update.ts
+++ b/src/hooks/customType-asset-update.ts
@@ -1,0 +1,44 @@
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `custom-type:asset:update` hook handlers.
+ */
+export type CustomTypeAssetUpdateHookData = {
+	customTypeID: string;
+	asset: {
+		id: string;
+		data: Buffer;
+	};
+};
+
+/**
+ * Return value for `custom-type:asset:update` hook handlers.
+ */
+export type CustomTypeAssetUpdateHookReturnType = void;
+
+/**
+ * Base version of `custom-type:asset:update` without plugin runner context.
+ *
+ * @internal
+ */
+export type CustomTypeAssetUpdateHookBase = SliceMachineHook<
+	CustomTypeAssetUpdateHookData,
+	CustomTypeAssetUpdateHookReturnType
+>;
+
+/**
+ * Handler for the `custom-type:asset:update` hook. The hook is called when a
+ * Custom Type's asset needs to be created or updated.
+ *
+ * `custom-type:asset:update` is called when an asset needs to be saved for the
+ * first time or updated if it already exists.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type CustomTypeAssetUpdateHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<CustomTypeAssetUpdateHookBase, TPluginOptions>;

--- a/src/hooks/customType-create.ts
+++ b/src/hooks/customType-create.ts
@@ -1,0 +1,42 @@
+import type { CustomTypeModel } from "@prismicio/types";
+
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `custom-type:create` hook handlers.
+ */
+export type CustomTypeCreateHookData = {
+	model: CustomTypeModel;
+};
+
+/**
+ * Return value for `custom-type:create` hook handlers.
+ */
+export type CustomTypeCreateHookReturnType = void;
+
+/**
+ * Base version of `custom-type:create` without plugin runner context.
+ *
+ * @internal
+ */
+export type CustomTypeCreateHookBase = SliceMachineHook<
+	CustomTypeCreateHookData,
+	CustomTypeCreateHookReturnType
+>;
+
+/**
+ * Handler for the `custom-type:create` hook. The hook is called when a Custom
+ * Type is created.
+ *
+ * `custom-type:create` is only called the first time a Custom Type is saved.
+ * Subsequent saves will call the `custom-type:update` hook.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type CustomTypeCreateHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<CustomTypeCreateHookBase, TPluginOptions>;

--- a/src/hooks/customType-delete.ts
+++ b/src/hooks/customType-delete.ts
@@ -1,0 +1,40 @@
+import type { CustomTypeModel } from "@prismicio/types";
+
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `custom-type:delete` hook handlers.
+ */
+export type CustomTypeDeleteHookData = {
+	model: CustomTypeModel;
+};
+
+/**
+ * Return value for `custom-type:delete` hook handlers.
+ */
+export type CustomTypeDeleteHookReturnType = void;
+
+/**
+ * Base version of a `custom-type:delete` hook handler without plugin runner
+ * context.
+ *
+ * @internal
+ */
+export type CustomTypeDeleteHookBase = SliceMachineHook<
+	CustomTypeDeleteHookData,
+	CustomTypeDeleteHookReturnType
+>;
+
+/**
+ * Handler for the `custom-type:delete` hook. The hook is called when a Custom
+ * Type is deleted.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type CustomTypeDeleteHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<CustomTypeDeleteHookBase, TPluginOptions>;

--- a/src/hooks/customType-read.ts
+++ b/src/hooks/customType-read.ts
@@ -1,0 +1,46 @@
+import type { CustomTypeModel } from "@prismicio/types";
+
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `custom-type:read` hook handlers.
+ */
+export type CustomTypeReadHookData = {
+	id: string;
+};
+
+/**
+ * Return value for `custom-type:read` hook handlers.
+ */
+export type CustomTypeReadHookReturnType = {
+	model: CustomTypeModel;
+};
+
+/**
+ * Base version of a `custom-type:read` hook handler without plugin runner
+ * context.
+ *
+ * @internal
+ */
+export type CustomTypeReadHookBase = SliceMachineHook<
+	CustomTypeReadHookData,
+	CustomTypeReadHookReturnType
+>;
+
+/**
+ * Handler for the `custom-type:read` hook. The hook is called when a Custom
+ * Type's model is needed.
+ *
+ * This hook is **required** to be implemented by adapters.
+ *
+ * This hook will only be called in adapters.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type CustomTypeReadHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<CustomTypeReadHookBase, TPluginOptions>;

--- a/src/hooks/customType-update.ts
+++ b/src/hooks/customType-update.ts
@@ -1,0 +1,43 @@
+import type { CustomTypeModel } from "@prismicio/types";
+
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `custom-type:update` hook handlers.
+ */
+export type CustomTypeUpdateHookData = {
+	model: CustomTypeModel;
+};
+
+/**
+ * Return value for `custom-type:update` hook handlers.
+ */
+export type CustomTypeUpdateHookReturnType = void;
+
+/**
+ * Base version of a `custom-type:update` hook handler without plugin runner
+ * context.
+ *
+ * @internal
+ */
+export type CustomTypeUpdateHookBase = SliceMachineHook<
+	CustomTypeUpdateHookData,
+	CustomTypeUpdateHookReturnType
+>;
+
+/**
+ * Handler for the `custom-type:update` hook. The hook is called when a Custom
+ * Type is updated.
+ *
+ * `custom-type:update` is not called the first time a Custom Type is saved. The
+ * `custom-type:create` hook is called instead.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type CustomTypeUpdateHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<CustomTypeUpdateHookBase, TPluginOptions>;

--- a/src/hooks/customTypeLibrary-read.ts
+++ b/src/hooks/customTypeLibrary-read.ts
@@ -1,0 +1,38 @@
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `custom-type-library:read` hook handlers.
+ */
+export type CustomTypeLibraryReadHookData = undefined;
+
+/**
+ * Return value for `custom-type-library:read` hook handlers.
+ */
+export type CustomTypeLibraryReadHookReturnType = {
+	ids: string[];
+};
+
+/**
+ * Base version of a `custom-type-library:read` hook handler without plugin
+ * runner context.
+ *
+ * @internal
+ */
+export type CustomTypeLibraryReadHookBase = SliceMachineHook<
+	CustomTypeLibraryReadHookData,
+	CustomTypeLibraryReadHookReturnType
+>;
+
+/**
+ * Handler for the `custom-type-library:read` hook. The hook is called when a
+ * Custom Type Library's metadata is needed.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type CustomTypeLibraryReadHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<CustomTypeLibraryReadHookBase, TPluginOptions>;

--- a/src/hooks/slice-asset-delete.ts
+++ b/src/hooks/slice-asset-delete.ts
@@ -1,0 +1,39 @@
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `slice:asset:delete` hook handlers.
+ */
+export type SliceAssetDeleteHookData = {
+	libraryID: string;
+	sliceID: string;
+	assetID: string;
+};
+
+/**
+ * Return value for `slice:asset:delete` hook handlers.
+ */
+export type SliceAssetDeleteHookReturnType = void;
+
+/**
+ * Base version of `slice:asset:delete` without plugin runner context.
+ *
+ * @internal
+ */
+export type SliceAssetDeleteHookBase = SliceMachineHook<
+	SliceAssetDeleteHookData,
+	SliceAssetDeleteHookReturnType
+>;
+
+/**
+ * Handler for the `slice:asset:delete` hook. The hook is called when a Slice
+ * asset is deleted.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type SliceAssetDeleteHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceAssetDeleteHookBase, TPluginOptions>;

--- a/src/hooks/slice-asset-read.ts
+++ b/src/hooks/slice-asset-read.ts
@@ -1,0 +1,45 @@
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `slice:asset:read` hook handlers.
+ */
+export type SliceAssetReadHookData = {
+	libraryID: string;
+	sliceID: string;
+	assetID: string;
+};
+
+/**
+ * Return value for `slice:asset:read` hook handlers.
+ */
+export type SliceAssetReadHookReturnType = {
+	data: Buffer;
+};
+
+/**
+ * Base version of `slice:asset:read` without plugin runner context.
+ *
+ * @internal
+ */
+export type SliceAssetReadHookBase = SliceMachineHook<
+	SliceAssetReadHookData,
+	SliceAssetReadHookReturnType
+>;
+
+/**
+ * Handler for the `slice:asset:read` hook. The hook is called when a Slice's
+ * asset needs to be read.
+ *
+ * This hook is **required** to be implemented by adapters.
+ *
+ * This hook will only be called in adapters.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type SliceAssetReadHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceAssetReadHookBase, TPluginOptions>;

--- a/src/hooks/slice-asset-update.ts
+++ b/src/hooks/slice-asset-update.ts
@@ -1,0 +1,45 @@
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `slice:asset:update` hook handlers.
+ */
+export type SliceAssetUpdateHookData = {
+	libraryID: string;
+	sliceID: string;
+	asset: {
+		id: string;
+		data: Buffer;
+	};
+};
+
+/**
+ * Return value for `slice:asset:update` hook handlers.
+ */
+export type SliceAssetUpdateHookReturnType = void;
+
+/**
+ * Base version of `slice:asset:update` without plugin runner context.
+ *
+ * @internal
+ */
+export type SliceAssetUpdateHookBase = SliceMachineHook<
+	SliceAssetUpdateHookData,
+	SliceAssetUpdateHookReturnType
+>;
+
+/**
+ * Handler for the `slice:asset:update` hook. The hook is called when a Slice's
+ * asset needs to be created or updated.
+ *
+ * `slice:asset:update` is called when an asset needs to be saved for the first
+ * time or updated if it already exists.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type SliceAssetUpdateHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceAssetUpdateHookBase, TPluginOptions>;

--- a/src/hooks/slice-create.ts
+++ b/src/hooks/slice-create.ts
@@ -1,0 +1,43 @@
+import type { SharedSliceModel } from "@prismicio/types";
+
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `slice:create` hook handlers.
+ */
+export type SliceCreateHookData = {
+	libraryID: string;
+	model: SharedSliceModel;
+};
+
+/**
+ * Return value for `slice:create` hook handlers.
+ */
+export type SliceCreateHookReturnType = void;
+
+/**
+ * Base version of `slice:create` without plugin runner context.
+ *
+ * @internal
+ */
+export type SliceCreateHookBase = SliceMachineHook<
+	SliceCreateHookData,
+	SliceCreateHookReturnType
+>;
+
+/**
+ * Handler for the `slice:create` hook. The hook is called when a Slice is
+ * created.
+ *
+ * `slice:create` is only called the first time a Slice is saved. Subsequent
+ * saves will call the `slice:update` hook.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type SliceCreateHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceCreateHookBase, TPluginOptions>;

--- a/src/hooks/slice-delete.ts
+++ b/src/hooks/slice-delete.ts
@@ -1,0 +1,40 @@
+import type { SharedSliceModel } from "@prismicio/types";
+
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `slice:delete` hook handlers.
+ */
+export type SliceDeleteHookData = {
+	libraryID: string;
+	model: SharedSliceModel;
+};
+
+/**
+ * Return value for `slice:delete` hook handlers.
+ */
+export type SliceDeleteHookReturnType = void;
+
+/**
+ * Base version of a `slice:delete` hook handler without plugin runner context.
+ *
+ * @internal
+ */
+export type SliceDeleteHookBase = SliceMachineHook<
+	SliceDeleteHookData,
+	SliceDeleteHookReturnType
+>;
+
+/**
+ * Handler for the `slice:delete` hook. The hook is called when a Slice is
+ * deleted.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type SliceDeleteHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceDeleteHookBase, TPluginOptions>;

--- a/src/hooks/slice-read.ts
+++ b/src/hooks/slice-read.ts
@@ -1,0 +1,44 @@
+import type { SharedSliceModel } from "@prismicio/types";
+
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `slice:read` hook handlers.
+ */
+export type SliceReadHookData = {
+	libraryID: string;
+	sliceID: string;
+};
+
+/**
+ * Return value for `slice:read` hook handlers.
+ */
+export type SliceReadHookReturnType = { model: SharedSliceModel };
+
+/**
+ * Base version of a `slice:read` hook handler without plugin runner context.
+ *
+ * @internal
+ */
+export type SliceReadHookBase = SliceMachineHook<
+	SliceReadHookData,
+	SliceReadHookReturnType
+>;
+
+/**
+ * Handler for the `slice:read` hook. The hook is called when a Slice's model is
+ * needed.
+ *
+ * This hook is **required** to be implemented by adapters.
+ *
+ * This hook will only be called in adapters.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type SliceReadHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceReadHookBase, TPluginOptions>;

--- a/src/hooks/slice-update.ts
+++ b/src/hooks/slice-update.ts
@@ -1,0 +1,43 @@
+import type { SharedSliceModel } from "@prismicio/types";
+
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `slice:update` hook handlers.
+ */
+export type SliceUpdateHookData = {
+	libraryID: string;
+	model: SharedSliceModel;
+};
+
+/**
+ * Return value for `slice:update` hook handlers.
+ */
+export type SliceUpdateHookReturnType = void;
+
+/**
+ * Base version of a `slice:update` hook handler without plugin runner context.
+ *
+ * @internal
+ */
+export type SliceUpdateHookBase = SliceMachineHook<
+	SliceUpdateHookData,
+	SliceUpdateHookReturnType
+>;
+
+/**
+ * Handler for the `slice:update` hook. The hook is called when a Slice is
+ * updated.
+ *
+ * `slice:update` is not called the first time a Slice is saved. The
+ * `slice:create` hook is called instead.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type SliceUpdateHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceUpdateHookBase, TPluginOptions>;

--- a/src/hooks/sliceLibrary-read.ts
+++ b/src/hooks/sliceLibrary-read.ts
@@ -1,0 +1,41 @@
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceLibrary,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * Data provided to `slice-library:read` hook handlers.
+ */
+export type SliceLibraryReadHookData = {
+	libraryID: string;
+};
+
+/**
+ * Return value for `slice-library:read` hook handlers.
+ */
+export type SliceLibraryReadHookReturnType = SliceLibrary & {
+	sliceIDs: string[];
+};
+
+/**
+ * Base version of a `slice-library:read` hook handler without plugin runner
+ * context.
+ *
+ * @internal
+ */
+export type SliceLibraryReadHookBase = SliceMachineHook<
+	SliceLibraryReadHookData,
+	SliceLibraryReadHookReturnType
+>;
+
+/**
+ * Handler for the `slice-library:read` hook. The hook is called when a Slice
+ * Library's metadata is needed.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type SliceLibraryReadHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceLibraryReadHookBase, TPluginOptions>;

--- a/src/hooks/sliceSimulator-setup-read.ts
+++ b/src/hooks/sliceSimulator-setup-read.ts
@@ -1,0 +1,71 @@
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	Promisable,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * The type of validation result for a Slice Simulator set up step.
+ */
+export const SliceSimulatorSetupStepValidationMessageType = {
+	Error: "Error",
+	Warning: "Warning",
+} as const;
+
+/**
+ * An object representing validation for a Slice Simulator set up step.
+ */
+export type SliceSimulatorSetupStepValidationMessage = {
+	type: typeof SliceSimulatorSetupStepValidationMessageType[keyof typeof SliceSimulatorSetupStepValidationMessageType];
+	title: string;
+	message: string;
+};
+
+/**
+ * An object representing a step to set up Slice Simulator.
+ */
+export type SliceSimulatorSetupStep = {
+	title: string;
+	body: string;
+	validate?: () => Promisable<
+		| SliceSimulatorSetupStepValidationMessage
+		| SliceSimulatorSetupStepValidationMessage[]
+		| void
+	>;
+};
+
+/**
+ * Data provided to `slice-simulator:setup:read` hook handlers.
+ */
+export type SliceSimulatorSetupReadHookData = undefined;
+
+/**
+ * Return value for `slice-simulator:setup:read` hook handlers.
+ */
+export type SliceSimulatorSetupReadHookReturnType = SliceSimulatorSetupStep[];
+
+/**
+ * Base version of a `slice-simulator:setup:read` hook handler without plugin
+ * runner context.
+ *
+ * @internal
+ */
+export type SliceSimulatorSetupReadHookBase = SliceMachineHook<
+	undefined,
+	SliceSimulatorSetupReadHookReturnType
+>;
+
+/**
+ * Handler for the `slice-simulator:setup:read` hook. The hook is called when a
+ * Slice Simulator set up steps are needed.
+ *
+ * This hook is **required** to be implemented by adapters.
+ *
+ * This hook will only be called in adapters.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type SliceSimulatorSetupReadHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceSimulatorSetupReadHookBase, TPluginOptions>;

--- a/src/hooks/snippet-read.ts
+++ b/src/hooks/snippet-read.ts
@@ -1,0 +1,75 @@
+import type {
+	CustomTypeModel,
+	CustomTypeModelField,
+	CustomTypeModelFieldForGroup,
+	SharedSliceModel,
+} from "@prismicio/types";
+
+import type {
+	ExtendSliceMachineHook,
+	PluginOptions,
+	SliceMachineHook,
+} from "../types";
+
+/**
+ * An object representing a code snippet.
+ */
+export type Snippet = {
+	label: string;
+	language: string;
+	code: string;
+};
+
+/**
+ * The type of the root model containing a field.
+ */
+export const SnippetReadHookDataRootModelType = {
+	Slice: "Slice",
+	CustomType: "CustomType",
+} as const;
+
+/**
+ * Data provided to `snippet:read` hook handlers.
+ */
+export type SnippetReadHookData = {
+	fieldPath: string[];
+} & (
+	| {
+			rootModelType: typeof SnippetReadHookDataRootModelType.Slice;
+			rootModel: SharedSliceModel;
+			model: CustomTypeModelFieldForGroup;
+	  }
+	| {
+			rootModelType: typeof SnippetReadHookDataRootModelType.CustomType;
+			rootModel: CustomTypeModel;
+			model: CustomTypeModelField;
+	  }
+);
+
+/**
+ * Return value for `snippet:read` hook handlers.
+ */
+export type SnippetReadHookReturnType = Snippet | Snippet[] | undefined;
+
+/**
+ * Base version of a `snippet:read` hook handler without plugin runner context.
+ *
+ * @internal
+ */
+export type SnippetReadHookBase = SliceMachineHook<
+	SnippetReadHookData,
+	SnippetReadHookReturnType
+>;
+
+/**
+ * Handler for the `snippet:read` hook. The hook is called when a Slice Machine
+ * needs a code snippet to display with a Custom Type or Slice field.
+ *
+ * The returned snippet should be specific to the field. It should be code a
+ * user can use in their application.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
+export type SnippetReadHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SnippetReadHookBase, TPluginOptions>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
+///////////////////////////////////////////////////////////////////////////////
+//
 // Public (for plugin authors)
+//
+///////////////////////////////////////////////////////////////////////////////
 
 export { defineSliceMachinePlugin } from "./defineSliceMachinePlugin";
 export type { SliceMachinePlugin } from "./defineSliceMachinePlugin";
@@ -12,118 +16,160 @@ export type {
 export type { SliceMachineHelpers } from "./createSliceMachineHelpers";
 export type { SliceMachineContext } from "./createSliceMachineContext";
 
-export {
-	SliceMachineHookType,
-	SnippetReadHookDataRootModelType,
-	SliceSimulatorSetupStepValidationMessageType,
-} from "./types";
-
+export { SliceMachineHookType } from "./types";
 export type {
 	PluginOptions,
 	SliceMachineProject,
 	SliceMachineConfig,
 	SliceLibrary,
-	// Public hooks
-	//
-	// -- types
 	SliceMachineHooks,
 	SliceMachineHookTypes,
-	//
-	// -- slice:create
-	SliceCreateHook,
-	SliceCreateHookData,
-	SliceCreateHookReturnType,
-	//
-	// -- slice:update
-	SliceUpdateHook,
-	SliceUpdateHookData,
-	SliceUpdateHookReturnType,
-	//
-	// -- slice:delete
-	SliceDeleteHook,
-	SliceDeleteHookData,
-	SliceDeleteHookReturnType,
-	//
-	// -- slice:read
-	SliceReadHook,
-	SliceReadHookData,
-	SliceReadHookReturnType,
-	//
-	// -- slice:asset:update
-	SliceAssetUpdateHook,
-	SliceAssetUpdateHookData,
-	SliceAssetUpdateHookReturnType,
-	//
-	// -- slice:asset:delete
-	SliceAssetDeleteHook,
-	SliceAssetDeleteHookData,
-	SliceAssetDeleteHookReturnType,
-	//
-	// -- slice:asset:read
-	SliceAssetReadHook,
-	SliceAssetReadHookData,
-	SliceAssetReadHookReturnType,
-	//
-	// -- slice-library:read
-	SliceLibraryReadHook,
-	SliceLibraryReadHookData,
-	SliceLibraryReadHookReturnType,
-	//
-	// -- customType:create
-	CustomTypeCreateHook,
-	CustomTypeCreateHookData,
-	CustomTypeCreateHookReturnType,
-	//
-	// -- customType:update
-	CustomTypeUpdateHook,
-	CustomTypeUpdateHookData,
-	CustomTypeUpdateHookReturnType,
-	//
-	// -- customType:delete
-	CustomTypeDeleteHook,
-	CustomTypeDeleteHookData,
-	CustomTypeDeleteHookReturnType,
-	//
-	// -- customType:read
-	CustomTypeReadHook,
-	CustomTypeReadHookData,
-	CustomTypeReadHookReturnType,
-	//
-	// -- custom-type:asset:update
-	CustomTypeAssetUpdateHook,
-	CustomTypeAssetUpdateHookData,
-	CustomTypeAssetUpdateHookReturnType,
-	//
-	// -- custom-type:asset:delete
-	CustomTypeAssetDeleteHook,
-	CustomTypeAssetDeleteHookData,
-	CustomTypeAssetDeleteHookReturnType,
-	//
-	// -- custom-type:asset:read
-	CustomTypeAssetReadHook,
-	CustomTypeAssetReadHookData,
-	CustomTypeAssetReadHookReturnType,
-	//
-	// -- custom-type-library:read
-	CustomTypeLibraryReadHook,
-	CustomTypeLibraryReadHookReturnType,
-	//
-	// -- snippet:read
-	SnippetReadHook,
-	SnippetReadHookData,
-	SnippetReadHookReturnType,
-	SnippetDescriptor,
-	//
-	// -- slice-simulator:setup:read
-	SliceSimulatorSetupReadHook,
-	SliceSimulatorSetupReadHookReturnType,
-	SliceSimulatorSetupStep,
-	SliceSimulatorSetupStepValidationMessage,
 } from "./types";
 
 export { HookError } from "./lib";
 
+///////////////////////////////////////////////////////////////////////////////
+//
+// Hooks (for plugin authors)
+//
+///////////////////////////////////////////////////////////////////////////////
+
+// slice:asset:update
+export type {
+	SliceAssetUpdateHook,
+	SliceAssetUpdateHookData,
+	SliceAssetUpdateHookReturnType,
+} from "./hooks/slice-asset-update";
+
+// slice:asset:delete
+export type {
+	SliceAssetDeleteHook,
+	SliceAssetDeleteHookData,
+	SliceAssetDeleteHookReturnType,
+} from "./hooks/slice-asset-delete";
+
+// slice:asset:read
+export type {
+	SliceAssetReadHook,
+	SliceAssetReadHookData,
+	SliceAssetReadHookReturnType,
+} from "./hooks/slice-asset-read";
+
+// slice:create
+export type {
+	SliceCreateHook,
+	SliceCreateHookData,
+	SliceCreateHookReturnType,
+} from "./hooks/slice-create";
+
+// slice:update
+export type {
+	SliceUpdateHook,
+	SliceUpdateHookData,
+	SliceUpdateHookReturnType,
+} from "./hooks/slice-update";
+
+// slice:delete
+export type {
+	SliceDeleteHook,
+	SliceDeleteHookData,
+	SliceDeleteHookReturnType,
+} from "./hooks/slice-delete";
+
+// slice:read
+export type {
+	SliceReadHook,
+	SliceReadHookData,
+	SliceReadHookReturnType,
+} from "./hooks/slice-read";
+
+// slice-library:read
+export type {
+	SliceLibraryReadHook,
+	SliceLibraryReadHookData,
+	SliceLibraryReadHookReturnType,
+} from "./hooks/sliceLibrary-read";
+
+// custom-type:asset:update
+export type {
+	CustomTypeAssetUpdateHook,
+	CustomTypeAssetUpdateHookData,
+	CustomTypeAssetUpdateHookReturnType,
+} from "./hooks/customType-asset-update";
+
+// custom-type:asset:delete
+export type {
+	CustomTypeAssetDeleteHook,
+	CustomTypeAssetDeleteHookData,
+	CustomTypeAssetDeleteHookReturnType,
+} from "./hooks/customType-asset-delete";
+
+// custom-type:asset:read
+export type {
+	CustomTypeAssetReadHook,
+	CustomTypeAssetReadHookData,
+	CustomTypeAssetReadHookReturnType,
+} from "./hooks/customType-asset-read";
+
+// custom-type:create
+export type {
+	CustomTypeCreateHook,
+	CustomTypeCreateHookData,
+	CustomTypeCreateHookReturnType,
+} from "./hooks/customType-create";
+
+// custom-type:update
+export type {
+	CustomTypeUpdateHook,
+	CustomTypeUpdateHookData,
+	CustomTypeUpdateHookReturnType,
+} from "./hooks/customType-update";
+
+// custom-type:delete
+export type {
+	CustomTypeDeleteHook,
+	CustomTypeDeleteHookData,
+	CustomTypeDeleteHookReturnType,
+} from "./hooks/customType-delete";
+
+// custom-type:read
+export type {
+	CustomTypeReadHook,
+	CustomTypeReadHookData,
+	CustomTypeReadHookReturnType,
+} from "./hooks/customType-read";
+
+// custom-type-library:read
+export type {
+	CustomTypeLibraryReadHook,
+	CustomTypeLibraryReadHookData,
+	CustomTypeLibraryReadHookReturnType,
+} from "./hooks/customTypeLibrary-read";
+
+// snippet:read
+export { SnippetReadHookDataRootModelType } from "./hooks/snippet-read";
+export type {
+	SnippetReadHook,
+	SnippetReadHookData,
+	SnippetReadHookReturnType,
+	Snippet,
+} from "./hooks/snippet-read";
+
+// slice-simulator-setup:read
+export { SliceSimulatorSetupStepValidationMessageType } from "./hooks/sliceSimulator-setup-read";
+export type {
+	SliceSimulatorSetupReadHook,
+	SliceSimulatorSetupReadHookData,
+	SliceSimulatorSetupReadHookReturnType,
+	SliceSimulatorSetupStep,
+	SliceSimulatorSetupStepValidationMessage,
+} from "./hooks/sliceSimulator-setup-read";
+
+///////////////////////////////////////////////////////////////////////////////
+//
 // Internal (for Slice Machine)
+//
+///////////////////////////////////////////////////////////////////////////////
 
 export { createSliceMachinePluginRunner } from "./createSliceMachinePluginRunner";
 export type { SliceMachinePluginRunner } from "./createSliceMachinePluginRunner";

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,19 +32,37 @@ export type {
 	// -- slice:create
 	SliceCreateHook,
 	SliceCreateHookData,
+	SliceCreateHookReturnType,
 	//
 	// -- slice:update
 	SliceUpdateHook,
 	SliceUpdateHookData,
+	SliceUpdateHookReturnType,
 	//
 	// -- slice:delete
 	SliceDeleteHook,
 	SliceDeleteHookData,
+	SliceDeleteHookReturnType,
 	//
 	// -- slice:read
 	SliceReadHook,
 	SliceReadHookData,
 	SliceReadHookReturnType,
+	//
+	// -- slice:asset:update
+	SliceAssetUpdateHook,
+	SliceAssetUpdateHookData,
+	SliceAssetUpdateHookReturnType,
+	//
+	// -- slice:asset:delete
+	SliceAssetDeleteHook,
+	SliceAssetDeleteHookData,
+	SliceAssetDeleteHookReturnType,
+	//
+	// -- slice:asset:read
+	SliceAssetReadHook,
+	SliceAssetReadHookData,
+	SliceAssetReadHookReturnType,
 	//
 	// -- slice-library:read
 	SliceLibraryReadHook,
@@ -54,19 +72,37 @@ export type {
 	// -- customType:create
 	CustomTypeCreateHook,
 	CustomTypeCreateHookData,
+	CustomTypeCreateHookReturnType,
 	//
 	// -- customType:update
 	CustomTypeUpdateHook,
 	CustomTypeUpdateHookData,
+	CustomTypeUpdateHookReturnType,
 	//
 	// -- customType:delete
 	CustomTypeDeleteHook,
 	CustomTypeDeleteHookData,
+	CustomTypeDeleteHookReturnType,
 	//
 	// -- customType:read
 	CustomTypeReadHook,
 	CustomTypeReadHookData,
 	CustomTypeReadHookReturnType,
+	//
+	// -- custom-type:asset:update
+	CustomTypeAssetUpdateHook,
+	CustomTypeAssetUpdateHookData,
+	CustomTypeAssetUpdateHookReturnType,
+	//
+	// -- custom-type:asset:delete
+	CustomTypeAssetDeleteHook,
+	CustomTypeAssetDeleteHookData,
+	CustomTypeAssetDeleteHookReturnType,
+	//
+	// -- custom-type:asset:read
+	CustomTypeAssetReadHook,
+	CustomTypeAssetReadHookData,
+	CustomTypeAssetReadHookReturnType,
 	//
 	// -- custom-type-library:read
 	CustomTypeLibraryReadHook,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,43 @@
-import * as prismicT from "@prismicio/types";
-
 import { SliceMachineContext } from "./createSliceMachineContext";
 import { SliceMachinePlugin } from "./defineSliceMachinePlugin";
 import { Hook } from "./lib";
 
-type Promisable<T> = T | PromiseLike<T>;
+import { CustomTypeAssetDeleteHookBase } from "./hooks/customType-asset-delete";
+import { CustomTypeAssetReadHookBase } from "./hooks/customType-asset-read";
+import { CustomTypeAssetUpdateHookBase } from "./hooks/customType-asset-update";
+import { CustomTypeCreateHookBase } from "./hooks/customType-create";
+import { CustomTypeDeleteHookBase } from "./hooks/customType-delete";
+import { CustomTypeLibraryReadHookBase } from "./hooks/customTypeLibrary-read";
+import { CustomTypeReadHookBase } from "./hooks/customType-read";
+import { CustomTypeUpdateHookBase } from "./hooks/customType-update";
+import { SliceAssetDeleteHookBase } from "./hooks/slice-asset-delete";
+import { SliceAssetReadHookBase } from "./hooks/slice-asset-read";
+import { SliceAssetUpdateHookBase } from "./hooks/slice-asset-update";
+import { SliceCreateHookBase } from "./hooks/slice-create";
+import { SliceDeleteHookBase } from "./hooks/slice-delete";
+import { SliceLibraryReadHookBase } from "./hooks/sliceLibrary-read";
+import { SliceReadHookBase } from "./hooks/slice-read";
+import { SliceSimulatorSetupReadHookBase } from "./hooks/sliceSimulator-setup-read";
+import { SliceUpdateHookBase } from "./hooks/slice-update";
+import { SnippetReadHookBase } from "./hooks/snippet-read";
 
+/**
+ * A value optionally wrapped in a `PromiseLike`.
+ *
+ * @typeParam T - The value that can optionally be wrapped.
+ */
+export type Promisable<T> = T | PromiseLike<T>;
+
+/**
+ * A generic type for a user-provided plugin options. Prefer using a
+ * plugin-specific type over this type.
+ */
 export type PluginOptions = Record<string, unknown>;
 
 /**
- * How plugins are registered.
+ * A string, object, or instance representing a registered plugin.
+ *
+ * @typeParam TPluginOptions - User-provided options for the plugin.
  */
 export type SliceMachineConfigPluginRegistration<
 	TPluginOptions extends PluginOptions = PluginOptions,
@@ -22,7 +50,7 @@ export type SliceMachineConfigPluginRegistration<
 	  };
 
 /**
- * Slice Machine `sm.json` config.
+ * Slice Machine `sm.json` configuration.
  */
 export type SliceMachineConfig = {
 	_latest: string;
@@ -33,6 +61,9 @@ export type SliceMachineConfig = {
 	plugins?: SliceMachineConfigPluginRegistration[];
 };
 
+/**
+ * Slice Machine project metadata.
+ */
 export type SliceMachineProject = {
 	/**
 	 * An absolute path to project root.
@@ -44,6 +75,9 @@ export type SliceMachineProject = {
 	config: SliceMachineConfig;
 };
 
+/**
+ * A Slice Library's metadata.
+ */
 export type SliceLibrary = {
 	id: string;
 };
@@ -54,14 +88,29 @@ export type SliceLibrary = {
 //
 // ============================================================================
 
+/**
+ * A hook handler.
+ */
 export type SliceMachineHook<TData, TReturn> = (
 	data: TData,
 ) => Promisable<TReturn>;
 
+/**
+ * Extra arguments provided to hooks when called.
+ *
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
 export type SliceMachineHookExtraArgs<
 	TPluginOptions extends PluginOptions = PluginOptions,
 > = [context: SliceMachineContext<TPluginOptions>];
 
+/**
+ * Utility type to extend a hook handler's type with Slice Machine-specific
+ * extra arguments.
+ *
+ * @typeParam THook - Hook handler to extend.
+ * @typeParam TPluginOptions - User-provided options for the hook's plugin.
+ */
 export type ExtendSliceMachineHook<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	THook extends SliceMachineHook<any, any>,
@@ -73,6 +122,9 @@ export type ExtendSliceMachineHook<
 	]
 ) => ReturnType<THook>;
 
+/**
+ * Hook types.
+ */
 export const SliceMachineHookType = {
 	slice_create: "slice:create",
 	slice_update: "slice:update",
@@ -97,9 +149,15 @@ export const SliceMachineHookType = {
 	sliceSimulator_setup_read: "slice-simulator:setup:read",
 } as const;
 
+/**
+ * Hook types.
+ */
 export type SliceMachineHookTypes =
 	typeof SliceMachineHookType[keyof typeof SliceMachineHookType];
 
+/**
+ * Slice Machine-specific hook handlers.
+ */
 export type SliceMachineHooks = {
 	// Slices
 	[SliceMachineHookType.slice_create]: Hook<SliceCreateHookBase>;
@@ -131,353 +189,3 @@ export type SliceMachineHooks = {
 	// Slice Simulator
 	[SliceMachineHookType.sliceSimulator_setup_read]: Hook<SliceSimulatorSetupReadHookBase>;
 };
-
-// ============================================================================
-// ## slice:create
-// ============================================================================
-
-export type SliceCreateHookData = {
-	libraryID: string;
-	model: prismicT.SharedSliceModel;
-};
-export type SliceCreateHookReturnType = void;
-export type SliceCreateHookBase = SliceMachineHook<
-	SliceCreateHookData,
-	SliceCreateHookReturnType
->;
-export type SliceCreateHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<SliceCreateHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## slice:update
-// ============================================================================
-
-export type SliceUpdateHookData = {
-	libraryID: string;
-	model: prismicT.SharedSliceModel;
-};
-export type SliceUpdateHookReturnType = void;
-export type SliceUpdateHookBase = SliceMachineHook<
-	SliceUpdateHookData,
-	SliceUpdateHookReturnType
->;
-export type SliceUpdateHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<SliceUpdateHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## slice:delete
-// ============================================================================
-
-export type SliceDeleteHookData = {
-	libraryID: string;
-	model: prismicT.SharedSliceModel;
-};
-export type SliceDeleteHookReturnType = void;
-export type SliceDeleteHookBase = SliceMachineHook<
-	SliceDeleteHookData,
-	SliceDeleteHookReturnType
->;
-export type SliceDeleteHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<SliceDeleteHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## slice:read
-// ============================================================================
-
-export type SliceReadHookData = {
-	libraryID: string;
-	sliceID: string;
-};
-export type SliceReadHookReturnType = { model: prismicT.SharedSliceModel };
-export type SliceReadHookBase = SliceMachineHook<
-	SliceReadHookData,
-	SliceReadHookReturnType
->;
-export type SliceReadHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<SliceReadHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## slice:asset:update
-// ============================================================================
-
-export type SliceAssetUpdateHookData = {
-	libraryID: string;
-	sliceID: string;
-	asset: {
-		id: string;
-		data: Buffer;
-	};
-};
-export type SliceAssetUpdateHookReturnType = void;
-export type SliceAssetUpdateHookBase = SliceMachineHook<
-	SliceAssetUpdateHookData,
-	SliceAssetUpdateHookReturnType
->;
-export type SliceAssetUpdateHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<SliceAssetUpdateHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## slice:asset:delete
-// ============================================================================
-
-export type SliceAssetDeleteHookData = {
-	libraryID: string;
-	sliceID: string;
-	assetID: string;
-};
-export type SliceAssetDeleteHookReturnType = void;
-export type SliceAssetDeleteHookBase = SliceMachineHook<
-	SliceAssetDeleteHookData,
-	SliceAssetDeleteHookReturnType
->;
-export type SliceAssetDeleteHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<SliceAssetDeleteHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## slice:asset:read
-// ============================================================================
-
-export type SliceAssetReadHookData = {
-	libraryID: string;
-	sliceID: string;
-	assetID: string;
-};
-export type SliceAssetReadHookReturnType = {
-	data: Buffer;
-};
-export type SliceAssetReadHookBase = SliceMachineHook<
-	SliceAssetReadHookData,
-	SliceAssetReadHookReturnType
->;
-export type SliceAssetReadHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<SliceAssetReadHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## slice-library:read
-// ============================================================================
-
-export type SliceLibraryReadHookData = {
-	libraryID: string;
-};
-export type SliceLibraryReadHookReturnType = SliceLibrary & {
-	sliceIDs: string[];
-};
-export type SliceLibraryReadHookBase = SliceMachineHook<
-	SliceLibraryReadHookData,
-	SliceLibraryReadHookReturnType
->;
-export type SliceLibraryReadHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<SliceLibraryReadHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## custom-type:create
-// ============================================================================
-
-export type CustomTypeCreateHookData = {
-	model: prismicT.CustomTypeModel;
-};
-export type CustomTypeCreateHookReturnType = void;
-export type CustomTypeCreateHookBase = SliceMachineHook<
-	CustomTypeCreateHookData,
-	CustomTypeCreateHookReturnType
->;
-export type CustomTypeCreateHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<CustomTypeCreateHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## custom-type:update
-// ============================================================================
-
-export type CustomTypeUpdateHookData = {
-	model: prismicT.CustomTypeModel;
-};
-export type CustomTypeUpdateHookReturnType = void;
-export type CustomTypeUpdateHookBase = SliceMachineHook<
-	CustomTypeUpdateHookData,
-	CustomTypeUpdateHookReturnType
->;
-export type CustomTypeUpdateHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<CustomTypeUpdateHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## custom-type:delete
-// ============================================================================
-
-export type CustomTypeDeleteHookData = {
-	model: prismicT.CustomTypeModel;
-};
-export type CustomTypeDeleteHookReturnType = void;
-export type CustomTypeDeleteHookBase = SliceMachineHook<
-	CustomTypeDeleteHookData,
-	CustomTypeDeleteHookReturnType
->;
-export type CustomTypeDeleteHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<CustomTypeDeleteHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## custom-type:read
-// ============================================================================
-
-export type CustomTypeReadHookData = {
-	id: string;
-};
-export type CustomTypeReadHookReturnType = { model: prismicT.CustomTypeModel };
-export type CustomTypeReadHookBase = SliceMachineHook<
-	CustomTypeReadHookData,
-	CustomTypeReadHookReturnType
->;
-export type CustomTypeReadHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<CustomTypeReadHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## slice:asset:update
-// ============================================================================
-
-export type CustomTypeAssetUpdateHookData = {
-	customTypeID: string;
-	asset: {
-		id: string;
-		data: Buffer;
-	};
-};
-export type CustomTypeAssetUpdateHookReturnType = void;
-export type CustomTypeAssetUpdateHookBase = SliceMachineHook<
-	CustomTypeAssetUpdateHookData,
-	CustomTypeAssetUpdateHookReturnType
->;
-export type CustomTypeAssetUpdateHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<CustomTypeAssetUpdateHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## slice:asset:delete
-// ============================================================================
-
-export type CustomTypeAssetDeleteHookData = {
-	customTypeID: string;
-	assetID: string;
-};
-export type CustomTypeAssetDeleteHookReturnType = void;
-export type CustomTypeAssetDeleteHookBase = SliceMachineHook<
-	CustomTypeAssetDeleteHookData,
-	CustomTypeAssetDeleteHookReturnType
->;
-export type CustomTypeAssetDeleteHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<CustomTypeAssetDeleteHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## slice:asset:read
-// ============================================================================
-
-export type CustomTypeAssetReadHookData = {
-	customTypeID: string;
-	assetID: string;
-};
-export type CustomTypeAssetReadHookReturnType = {
-	data: Buffer;
-};
-export type CustomTypeAssetReadHookBase = SliceMachineHook<
-	CustomTypeAssetReadHookData,
-	CustomTypeAssetReadHookReturnType
->;
-export type CustomTypeAssetReadHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<CustomTypeAssetReadHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## custom-type-library:read
-// ============================================================================
-
-export type CustomTypeLibraryReadHookReturnType = {
-	ids: string[];
-};
-export type CustomTypeLibraryReadHookBase = SliceMachineHook<
-	undefined,
-	CustomTypeLibraryReadHookReturnType
->;
-export type CustomTypeLibraryReadHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<CustomTypeLibraryReadHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## snippet:read
-// ============================================================================
-
-export const SnippetReadHookDataRootModelType = {
-	Slice: "Slice",
-	CustomType: "CustomType",
-} as const;
-export type SnippetReadHookData = {
-	fieldPath: string[];
-} & (
-	| {
-			rootModelType: typeof SnippetReadHookDataRootModelType.Slice;
-			rootModel: prismicT.SharedSliceModel;
-			model: prismicT.CustomTypeModelFieldForGroup;
-	  }
-	| {
-			rootModelType: typeof SnippetReadHookDataRootModelType.CustomType;
-			rootModel: prismicT.CustomTypeModel;
-			model: prismicT.CustomTypeModelField;
-	  }
-);
-export type SnippetDescriptor = {
-	label: string;
-	language: string;
-	code: string;
-};
-export type SnippetReadHookReturnType =
-	| SnippetDescriptor
-	| SnippetDescriptor[]
-	| undefined;
-export type SnippetReadHookBase = SliceMachineHook<
-	SnippetReadHookData,
-	SnippetReadHookReturnType
->;
-export type SnippetReadHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<SnippetReadHookBase, TPluginOptions>;
-
-// ============================================================================
-// ## slice-simulator:setup:read
-// ============================================================================
-
-export const SliceSimulatorSetupStepValidationMessageType = {
-	Error: "Error",
-	Warning: "Warning",
-} as const;
-export type SliceSimulatorSetupStepValidationMessage = {
-	type: typeof SliceSimulatorSetupStepValidationMessageType[keyof typeof SliceSimulatorSetupStepValidationMessageType];
-	title: string;
-	message: string;
-};
-export type SliceSimulatorSetupStep = {
-	title: string;
-	body: string;
-	validate?: () => Promisable<
-		| SliceSimulatorSetupStepValidationMessage
-		| SliceSimulatorSetupStepValidationMessage[]
-		| void
-	>;
-};
-export type SliceSimulatorSetupReadHookReturnType = SliceSimulatorSetupStep[];
-export type SliceSimulatorSetupReadHookBase = SliceMachineHook<
-	undefined,
-	SliceSimulatorSetupReadHookReturnType
->;
-export type SliceSimulatorSetupReadHook<
-	TPluginOptions extends PluginOptions = PluginOptions,
-> = ExtendSliceMachineHook<SliceSimulatorSetupReadHookBase, TPluginOptions>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,13 +78,22 @@ export const SliceMachineHookType = {
 	slice_update: "slice:update",
 	slice_delete: "slice:delete",
 	slice_read: "slice:read",
+	slice_asset_update: "slice:asset:update",
+	slice_asset_delete: "slice:asset:delete",
+	slice_asset_read: "slice:asset:read",
 	sliceLibrary_read: "slice-library:read",
+
 	customType_create: "custom-type:create",
 	customType_update: "custom-type:update",
 	customType_delete: "custom-type:delete",
 	customType_read: "custom-type:read",
+	customType_asset_update: "custom-type:asset:update",
+	customType_asset_delete: "custom-type:asset:delete",
+	customType_asset_read: "custom-type:asset:read",
 	customTypeLibrary_read: "custom-type-library:read",
+
 	snippet_read: "snippet:read",
+
 	sliceSimulator_setup_read: "slice-simulator:setup:read",
 } as const;
 
@@ -97,6 +106,9 @@ export type SliceMachineHooks = {
 	[SliceMachineHookType.slice_update]: Hook<SliceUpdateHookBase>;
 	[SliceMachineHookType.slice_delete]: Hook<SliceDeleteHookBase>;
 	[SliceMachineHookType.slice_read]: Hook<SliceReadHookBase>;
+	[SliceMachineHookType.slice_asset_update]: Hook<SliceAssetUpdateHookBase>;
+	[SliceMachineHookType.slice_asset_delete]: Hook<SliceAssetDeleteHookBase>;
+	[SliceMachineHookType.slice_asset_read]: Hook<SliceAssetReadHookBase>;
 
 	// Slice Libraries
 	[SliceMachineHookType.sliceLibrary_read]: Hook<SliceLibraryReadHookBase>;
@@ -106,6 +118,9 @@ export type SliceMachineHooks = {
 	[SliceMachineHookType.customType_update]: Hook<CustomTypeUpdateHookBase>;
 	[SliceMachineHookType.customType_delete]: Hook<CustomTypeDeleteHookBase>;
 	[SliceMachineHookType.customType_read]: Hook<CustomTypeReadHookBase>;
+	[SliceMachineHookType.customType_asset_update]: Hook<CustomTypeAssetUpdateHookBase>;
+	[SliceMachineHookType.customType_asset_delete]: Hook<CustomTypeAssetDeleteHookBase>;
+	[SliceMachineHookType.customType_asset_read]: Hook<CustomTypeAssetReadHookBase>;
 
 	// Custom Type Libraries
 	[SliceMachineHookType.customTypeLibrary_read]: Hook<CustomTypeLibraryReadHookBase>;
@@ -125,7 +140,11 @@ export type SliceCreateHookData = {
 	libraryID: string;
 	model: prismicT.SharedSliceModel;
 };
-export type SliceCreateHookBase = SliceMachineHook<SliceCreateHookData, void>;
+export type SliceCreateHookReturnType = void;
+export type SliceCreateHookBase = SliceMachineHook<
+	SliceCreateHookData,
+	SliceCreateHookReturnType
+>;
 export type SliceCreateHook<
 	TPluginOptions extends PluginOptions = PluginOptions,
 > = ExtendSliceMachineHook<SliceCreateHookBase, TPluginOptions>;
@@ -138,7 +157,11 @@ export type SliceUpdateHookData = {
 	libraryID: string;
 	model: prismicT.SharedSliceModel;
 };
-export type SliceUpdateHookBase = SliceMachineHook<SliceUpdateHookData, void>;
+export type SliceUpdateHookReturnType = void;
+export type SliceUpdateHookBase = SliceMachineHook<
+	SliceUpdateHookData,
+	SliceUpdateHookReturnType
+>;
 export type SliceUpdateHook<
 	TPluginOptions extends PluginOptions = PluginOptions,
 > = ExtendSliceMachineHook<SliceUpdateHookBase, TPluginOptions>;
@@ -151,7 +174,11 @@ export type SliceDeleteHookData = {
 	libraryID: string;
 	model: prismicT.SharedSliceModel;
 };
-export type SliceDeleteHookBase = SliceMachineHook<SliceDeleteHookData, void>;
+export type SliceDeleteHookReturnType = void;
+export type SliceDeleteHookBase = SliceMachineHook<
+	SliceDeleteHookData,
+	SliceDeleteHookReturnType
+>;
 export type SliceDeleteHook<
 	TPluginOptions extends PluginOptions = PluginOptions,
 > = ExtendSliceMachineHook<SliceDeleteHookBase, TPluginOptions>;
@@ -172,6 +199,65 @@ export type SliceReadHookBase = SliceMachineHook<
 export type SliceReadHook<
 	TPluginOptions extends PluginOptions = PluginOptions,
 > = ExtendSliceMachineHook<SliceReadHookBase, TPluginOptions>;
+
+// ============================================================================
+// ## slice:asset:update
+// ============================================================================
+
+export type SliceAssetUpdateHookData = {
+	libraryID: string;
+	sliceID: string;
+	asset: {
+		id: string;
+		data: Buffer;
+	};
+};
+export type SliceAssetUpdateHookReturnType = void;
+export type SliceAssetUpdateHookBase = SliceMachineHook<
+	SliceAssetUpdateHookData,
+	SliceAssetUpdateHookReturnType
+>;
+export type SliceAssetUpdateHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceAssetUpdateHookBase, TPluginOptions>;
+
+// ============================================================================
+// ## slice:asset:delete
+// ============================================================================
+
+export type SliceAssetDeleteHookData = {
+	libraryID: string;
+	sliceID: string;
+	assetID: string;
+};
+export type SliceAssetDeleteHookReturnType = void;
+export type SliceAssetDeleteHookBase = SliceMachineHook<
+	SliceAssetDeleteHookData,
+	SliceAssetDeleteHookReturnType
+>;
+export type SliceAssetDeleteHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceAssetDeleteHookBase, TPluginOptions>;
+
+// ============================================================================
+// ## slice:asset:read
+// ============================================================================
+
+export type SliceAssetReadHookData = {
+	libraryID: string;
+	sliceID: string;
+	assetID: string;
+};
+export type SliceAssetReadHookReturnType = {
+	data: Buffer;
+};
+export type SliceAssetReadHookBase = SliceMachineHook<
+	SliceAssetReadHookData,
+	SliceAssetReadHookReturnType
+>;
+export type SliceAssetReadHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<SliceAssetReadHookBase, TPluginOptions>;
 
 // ============================================================================
 // ## slice-library:read
@@ -198,9 +284,10 @@ export type SliceLibraryReadHook<
 export type CustomTypeCreateHookData = {
 	model: prismicT.CustomTypeModel;
 };
+export type CustomTypeCreateHookReturnType = void;
 export type CustomTypeCreateHookBase = SliceMachineHook<
 	CustomTypeCreateHookData,
-	void
+	CustomTypeCreateHookReturnType
 >;
 export type CustomTypeCreateHook<
 	TPluginOptions extends PluginOptions = PluginOptions,
@@ -213,9 +300,10 @@ export type CustomTypeCreateHook<
 export type CustomTypeUpdateHookData = {
 	model: prismicT.CustomTypeModel;
 };
+export type CustomTypeUpdateHookReturnType = void;
 export type CustomTypeUpdateHookBase = SliceMachineHook<
 	CustomTypeUpdateHookData,
-	void
+	CustomTypeUpdateHookReturnType
 >;
 export type CustomTypeUpdateHook<
 	TPluginOptions extends PluginOptions = PluginOptions,
@@ -228,9 +316,10 @@ export type CustomTypeUpdateHook<
 export type CustomTypeDeleteHookData = {
 	model: prismicT.CustomTypeModel;
 };
+export type CustomTypeDeleteHookReturnType = void;
 export type CustomTypeDeleteHookBase = SliceMachineHook<
 	CustomTypeDeleteHookData,
-	void
+	CustomTypeDeleteHookReturnType
 >;
 export type CustomTypeDeleteHook<
 	TPluginOptions extends PluginOptions = PluginOptions,
@@ -251,6 +340,62 @@ export type CustomTypeReadHookBase = SliceMachineHook<
 export type CustomTypeReadHook<
 	TPluginOptions extends PluginOptions = PluginOptions,
 > = ExtendSliceMachineHook<CustomTypeReadHookBase, TPluginOptions>;
+
+// ============================================================================
+// ## slice:asset:update
+// ============================================================================
+
+export type CustomTypeAssetUpdateHookData = {
+	customTypeID: string;
+	asset: {
+		id: string;
+		data: Buffer;
+	};
+};
+export type CustomTypeAssetUpdateHookReturnType = void;
+export type CustomTypeAssetUpdateHookBase = SliceMachineHook<
+	CustomTypeAssetUpdateHookData,
+	CustomTypeAssetUpdateHookReturnType
+>;
+export type CustomTypeAssetUpdateHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<CustomTypeAssetUpdateHookBase, TPluginOptions>;
+
+// ============================================================================
+// ## slice:asset:delete
+// ============================================================================
+
+export type CustomTypeAssetDeleteHookData = {
+	customTypeID: string;
+	assetID: string;
+};
+export type CustomTypeAssetDeleteHookReturnType = void;
+export type CustomTypeAssetDeleteHookBase = SliceMachineHook<
+	CustomTypeAssetDeleteHookData,
+	CustomTypeAssetDeleteHookReturnType
+>;
+export type CustomTypeAssetDeleteHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<CustomTypeAssetDeleteHookBase, TPluginOptions>;
+
+// ============================================================================
+// ## slice:asset:read
+// ============================================================================
+
+export type CustomTypeAssetReadHookData = {
+	customTypeID: string;
+	assetID: string;
+};
+export type CustomTypeAssetReadHookReturnType = {
+	data: Buffer;
+};
+export type CustomTypeAssetReadHookBase = SliceMachineHook<
+	CustomTypeAssetReadHookData,
+	CustomTypeAssetReadHookReturnType
+>;
+export type CustomTypeAssetReadHook<
+	TPluginOptions extends PluginOptions = PluginOptions,
+> = ExtendSliceMachineHook<CustomTypeAssetReadHookBase, TPluginOptions>;
 
 // ============================================================================
 // ## custom-type-library:read


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR implements 6 new hooks to facilitate general Slice and Custom Type asset management:

- `slice:asset:update`
- `slice:asset:read`
- `slice:asset:delete`
- `custom-type:asset:update`
- `custom-type:asset:read`
- `custom-type:asset:delete`

All `*:asset:*` hooks are **required** by adapters as they implement crucial functionality needed by Slice Machine.

These hooks would be used for the following purposes

- Saving screenshots
- Saving mock values and/or configuration
- Saving any Slice- or Custom Type-specific asset-like data

For details on the technical decisions made behind these hooks, see the following comment thread: https://github.com/prismicio/slicemachine-plugin-kit/pull/2#pullrequestreview-1150680708

### Refactors

- Move all hook types from `src/types.ts` into per-hook files in `src/hooks`. The number of hooks and the verbosity of the types outgrew the single `types.ts` file.
- Add TSDocs to all hook types.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦒
