### PR TITLE
fix: allow all plugins to implement non-read asset hooks

### DIFF
--- a/src/createSliceMachinePluginRunner.ts
+++ b/src/createSliceMachinePluginRunner.ts
@@ -42,7 +42,15 @@ export const REQUIRED_ADAPTER_HOOKS: SliceMachineHookTypes[] = [
 /**
  * @internal
  */
-export const ADAPTER_ONLY_HOOKS = REQUIRED_ADAPTER_HOOKS;
+export const ADAPTER_ONLY_HOOKS: SliceMachineHookTypes[] = [
+	"slice:read",
+	"slice:asset:read",
+	"slice-library:read",
+	"custom-type:read",
+	"custom-type:asset:read",
+	"custom-type-library:read",
+	"slice-simulator:setup:read",
+];
 
 type SliceMachinePluginRunnerConstructorArgs = {
 	project: SliceMachineProject;

--- a/test/SliceMachinePluginRunner-setupPlugin.test.ts
+++ b/test/SliceMachinePluginRunner-setupPlugin.test.ts
@@ -5,7 +5,10 @@ import * as plugin from "./__fixtures__/plugin";
 import { createSliceMachineProject } from "./__testutils__/createSliceMachineProject";
 
 import { createSliceMachinePluginRunner } from "../src";
-import { REQUIRED_ADAPTER_HOOKS } from "../src/createSliceMachinePluginRunner";
+import {
+	REQUIRED_ADAPTER_HOOKS,
+	ADAPTER_ONLY_HOOKS,
+} from "../src/createSliceMachinePluginRunner";
 
 const project = createSliceMachineProject(adapter.valid);
 const pluginRunner = createSliceMachinePluginRunner({ project });
@@ -77,5 +80,7 @@ it("prevents plugin setup as plugin to hook to adapter only hooks", async () => 
 		pluginRunner
 			.hooksForOwner(adapter.valid.meta.name)
 			.map((hook) => hook.meta.type),
-	).toStrictEqual([]);
+	).toStrictEqual(
+		REQUIRED_ADAPTER_HOOKS.filter((type) => !ADAPTER_ONLY_HOOKS.includes(type)),
+	);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR allows all plugins to register hook handlers for non-read `*:asset:*` hooks.

The `*:asset:read` hooks are still reserved only for adapters.

This change maintains support for monorepos via multiple adapters (being used as plugins).

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
