### PR TITLE
feat: add `includeNewlineAtEnd` option to `format` helper

### DIFF
--- a/src/createSliceMachineHelpers.ts
+++ b/src/createSliceMachineHelpers.ts
@@ -8,6 +8,12 @@ import { SliceMachineProject } from "./types";
 
 type FormatOptions = {
 	prettier?: prettier.Options;
+	/**
+	 * Determines if a newline is included at the end of the formatted result.
+	 *
+	 * @defaultValue `true`
+	 */
+	includeNewlineAtEnd?: boolean;
 };
 
 /**
@@ -63,6 +69,10 @@ export class SliceMachineHelpers {
 			filepath: filePath,
 			...(options?.prettier ?? {}),
 		});
+
+		if (options?.includeNewlineAtEnd === false) {
+			formatted = formatted.replace(/[\r\n]+$/, "");
+		}
 
 		return formatted;
 	};

--- a/test/SliceMachineHelpers-format.test.ts
+++ b/test/SliceMachineHelpers-format.test.ts
@@ -88,3 +88,19 @@ it("uses Prettier config file relative to the filepath when it exists", async ()
 
 	await fs.rm(project.root, { recursive: true });
 });
+
+it("removes newline at end of result if `includeNewlineAtEnd` is false", async () => {
+	const adapter = createTestAdapter();
+	const project = createSliceMachineProject(adapter);
+
+	const pluginRunner = createSliceMachinePluginRunner({ project });
+	await pluginRunner.init();
+
+	const input = "* List item";
+	const filePath = path.join(project.root, "foo.md");
+
+	const res = await pluginRunner.rawHelpers.format(input, filePath, {
+		includeNewlineAtEnd: false,
+	});
+	expect(res).toBe("- List item");
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds an `includeNewlineAtEnd` option to the `format()` helper. The option is implicitly `true` by default, which maintains backwards compatibility.

Prettier adds a newline at the end of the file to follow general file management conventions. This practice is helpful when using `format()` to format files, such as component files.

It is not helpful, however, when `format()` is used for non-file content, like Markdown codeblocks. In this case, an empty line was added to the output, causing the codeblocks to look like it had extra bottom padding.

### Example

```typescript
const exampleSMJSON = await helpers.format(
  source`
    {
      "localSliceSimulatorURL": "http://localhost:3000/slice-simulator"
    }
  `,
  filePath,
  { includeNewlineAtEnd: false }
);

const body = source`
  Update your \`sm.json\` file with a \`localSliceSimulatorURL\` property pointing to your \`slice-simulator\` page.

  ~~~json
  ${fileContents}
  ~~~
`;
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐈‍⬛
